### PR TITLE
Enable ImageBuilder

### DIFF
--- a/.github/workflows/build_mx4300_foss.yml
+++ b/.github/workflows/build_mx4300_foss.yml
@@ -52,4 +52,4 @@ jobs:
               uses: ncipollo/release-action@v1
               with:
                 tag: qualcommax-foss-${{ env.SHA }}
-                artifacts: bin/targets/qualcommax/ipq807x/openwrt-qualcommax-ipq807x-linksys_mx4300*
+                artifacts: bin/targets/qualcommax/ipq807x/openwrt-qualcommax-ipq807x-linksys_mx4300*, bin/targets/qualcommax/ipq807x/openwrt-imagebuilder-qualcommax-ipq807x.*, bin/targets/qualcommax/ipq807x/sha256sums

--- a/genconfig.sh
+++ b/genconfig.sh
@@ -4,7 +4,7 @@
 wget -qO- https://downloads.openwrt.org/snapshots/targets/qualcommax/ipq807x/config.buildinfo | grep -v CONFIG_TARGET_DEVICE_ | grep -v CONFIG_TARGET_ALL_PROFILES | grep -v CONFIG_TARGET_MULTI_PROFILE > .config
 echo CONFIG_TARGET_ALL_PROFILES=n >> .config
 echo CONFIG_TARGET_MULTI_PROFILE=n >> .config
-echo CONFIG_IB=n >> .config
+echo CONFIG_IB=y >> .config
 echo CONFIG_TARGET_qualcommax_ipq807x_DEVICE_linksys_mx4300=y >> .config
 echo CONFIG_TARGET_DEVICE_qualcommax_ipq807x_DEVICE_linksys_mx4300=y >> .config
 echo CONFIG_TARGET_DEVICE_PACKAGES_qualcommax_ipq807x_DEVICE_linksys_mx4300=\"\" >> .config


### PR DESCRIPTION
This would allow building custom images without recompiling the code, which is especially useful when you have to deploy to multiple mx4300.

The change also publishes the generated sha256sum, so the artifacts could be verified.
